### PR TITLE
Switch to NAME_ONLY path sensitivity

### DIFF
--- a/src/main/kotlin/com/netflix/gradle/jakartaee/JakartaEeMigrationTransform.kt
+++ b/src/main/kotlin/com/netflix/gradle/jakartaee/JakartaEeMigrationTransform.kt
@@ -96,7 +96,7 @@ internal abstract class JakartaEeMigrationTransform : TransformAction<JakartaEeM
         )
     }
 
-    @PathSensitive(PathSensitivity.RELATIVE)
+    @PathSensitive(PathSensitivity.NAME_ONLY)
     @InputArtifact
     abstract fun getInputArtifact(): Provider<FileSystemLocation>
 


### PR DESCRIPTION
Appears that for transforms, the fully qualified path still makes it into the fingerprint which prevents cache reuse.